### PR TITLE
Consider any file received on a service accouncement TMGI as SA

### DIFF
--- a/src/Middleware.cpp
+++ b/src/Middleware.cpp
@@ -64,7 +64,7 @@ void MBMS_RT::Middleware::tick_handler()
     auto files = service->fileList();
     for (const auto& file : files) {
       //_downloaded_files.insert_or_assign(file.location(), file);
-      if (file->meta().content_location.find("bootstrap.multipart") != std::string::npos && service->isServiceAnnouncement()) {
+      if (service->isServiceAnnouncement()) {
         if (!service->bootstrapped()) {
           service->tryParseBootstrapFile(file->buffer());
         }


### PR DESCRIPTION
Recent changes in the R&S core have changed the name of the service announcement file.

As the stream with the SA TMGI will only ever contain the service announcement, it should be safe to ignore the name (unless it's gzipped, when the Rel-9 branch handles)

This also links the latest commit in rt-libflute.