### PR TITLE
Support gzipped Service Announcement

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 	path = supporting_files/rt-common-shared
 	url = https://github.com/5G-MAG/rt-common-shared
 	branch = feature/mbms
+[submodule "lib/gzip-hpp"]
+	path = lib/gzip-hpp
+	url = git@github.com:mapbox/gzip-hpp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,8 @@ target_link_libraries( mw
     cpprestsdk::cpprest
     flute
     z
+    ssl
+    crypto
     PkgConfig::GMIME
     PkgConfig::TINYXML
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ include_directories(
     ${PROJECT_SOURCE_DIR}/src
     SYSTEM
     ${SPDLOG_INCLUDEDIR}
+    ${PROJECT_SOURCE_DIR}/lib/gzip-hpp/include
     PkgConfig::GMIME
     PkgConfig::TINYXML
     )

--- a/src/Middleware.cpp
+++ b/src/Middleware.cpp
@@ -94,11 +94,13 @@ void MBMS_RT::Middleware::tick_handler() {
     for (auto const &mtch: mch.at("mtchs").as_array()) {
       auto tmgi = mtch.at("tmgi").as_string();
       auto dest = mtch.at("dest").as_string();
+      unsigned tsi = 0;
+      _cfg.lookupValue("mw.service_announcement_tsi", tsi);
       auto is_service_announcement = std::stoul(tmgi.substr(0, 6), nullptr, 16) < 0xF;
       if (!dest.empty() && is_service_announcement && !_service_announcement) {
         // automatically start receiving the service announcement
         // 26.346 5.2.3.1.1 : the pre-defined TSI value shall be "0". 
-        _service_announcement = std::make_unique<MBMS_RT::ServiceAnnouncement>(_cfg, tmgi, dest, 0 /*TSI*/, _interface,
+        _service_announcement = std::make_unique<MBMS_RT::ServiceAnnouncement>(_cfg, tmgi, dest, tsi, _interface,
                                                                                _io_service,
                                                                                _cache, _seamless,
                                                                                boost::bind(&Middleware::get_service,


### PR DESCRIPTION
The R&S core (BSCC) now sends all service announcements compressed with GZIP.
This PR changes two things in order to maintain compatibility:

- check MIME type of files received in an SA service and gunzip the content if required
- ignore filenames, in a service with an SA TMGI all transmitted files should be considered as containing a service announcement

Additionally, the SA FLUTE TSI is now configurable:

````
mw: {
....
  service_announcement_tsi: 0;
....
}

````
